### PR TITLE
Fix incorrect artifactId

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ repositories {
 }
 
 dependencies {
-    compile 'team.birdhead.aspectratioimageview:aspectratioimageview:1.0.0'
+    implementation 'team.birdhead.licenseview:licenseview:1.0.0'
 }
 ```
 


### PR DESCRIPTION
The `artifactId` of `Download` section is incorrect which is referred other project.
I just fixed it.